### PR TITLE
Change data_category, data_type and data_format properties to string

### DIFF
--- a/gdcdictionary/schemas/reference_file.yaml
+++ b/gdcdictionary/schemas/reference_file.yaml
@@ -59,49 +59,19 @@ properties:
     type: string
 
   data_category:
-    term:
-      $ref: "_terms.yaml#/data_category"
-    enum:
-      - Sequencing Reference
-      - Variant Calling Reference
-      - Familial Reference
-      - Clinical Data
-      - Survey
-      - Other
+    description: >
+      Broad categorization of the contents of the data file.
+    type: string
 
   data_type:
-    term:
-      $ref: "_terms.yaml#/data_type"
-    enum:
-      - Sequencing Reference
-      - Variant Call
-      - Kinship Matrix
-      - Unharmonized Clinical Data
-      - Questionnaire data
-      - Other
+    description: >
+      Specific content type of the data file.
+    type: string
 
   data_format:
-    term:
-      $ref: "_terms.yaml#/data_format"
-    enum:
-      - FASTA
-      - FAI
-      - ALT
-      - BWT
-      - DTA
-      - PAC
-      - ANN
-      - AMB
-      - SA
-      - SAS
-      - TAR
-      - VCF
-      - BCF
-      - TBI
-      - GDS
-      - TXT
-      - RDATA
-      - AVRO
+    description: >
+      Format of the data files.
+    type: string
 
   core_metadata_collections:
     $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
### Description

This pull request changes the properties data_category, data_type and data_format (reference_file node) to string. We discussed this as a good temporary strategy for now while we build up the appropriate categories for these properties. Intention is to impose some structure on what is placed in these.

### New Features

### Breaking Changes

There are currently only 10 reference_file node instances in the entire commons. These are only test data and may be dropped.

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
