### PR TITLE
change relationship from reference_file to core_metadata_collection to many_to_many

### DIFF
--- a/gdcdictionary/schemas/reference_file.yaml
+++ b/gdcdictionary/schemas/reference_file.yaml
@@ -29,7 +29,7 @@ links:
         backref: reference_files
         label: data_from
         target_type: core_metadata_collection
-        multiplicity: many_to_one
+        multiplicity: many_to_many
         required: false
       - name: projects
         backref: reference_files


### PR DESCRIPTION
I just went over this change with Mike and Phil. In this case, we believe it can be made to the production instance directly without testing.