### PR TITLE
Bugfix: Multiracial was excluded in _definitions (previously hard coded in de…

### DIFF
--- a/gdcdictionary/schemas/_definitions.yaml
+++ b/gdcdictionary/schemas/_definitions.yaml
@@ -300,6 +300,7 @@ race:
     - Native Hawaiian or Other Pacific Islander
     - Asian
     - Some other race
+    - Multiracial
     - Not reported
 
 hispanic:


### PR DESCRIPTION
Multiracial was excluded in _definitions (previously hard coded in demographics yaml). 

Was added to __definitions to reduce redundancy as it is referenced two times (one in serious_adverse_event node and the other in the demographic node). The SAE node does not have multiracial but is needed for demographic node.